### PR TITLE
Изменен способ запуска сервера, добавлен конфиг, тесты

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ venv
 .env
 __pycache__/
 */__pycache__/
+.pytest_cache
 *.py[cod]
 .pyc
 *.pyc

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ pip install -r requirements.txt
 
 5. Запустите сервер:
 ```
-uvicorn app.main:app --reload
+python app/main.py
 ```
 Для отключения сервера используйте команду:
 ```

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+from pydantic_settings import BaseSettings
+
+
+class RunConfig(BaseModel):
+    """Параметры для запуска приложения"""
+
+    host: str = "0.0.0.0"
+    port: int = 8000
+
+
+class ApiPrefix(BaseModel):
+    prefix: str = "/api"
+
+
+class Settings(BaseSettings):
+    run: RunConfig = RunConfig()
+    api: ApiPrefix = ApiPrefix()
+
+
+settings = Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -1,14 +1,32 @@
-from fastapi import FastAPI
-from app.api import router as api_router
+import sys
+import os
+
+sys.path.append(os.path.dirname(__file__))
 
 
-app = FastAPI()
-app.include_router(
+from fastapi import FastAPI  # noqa: E402
+
+from api import router as api_router  # noqa: E402
+from core.config import settings  # noqa: E402
+
+import uvicorn  # noqa: E402
+
+
+application = FastAPI()
+application.include_router(
     api_router,
-    prefix="/api",
+    prefix=settings.api.prefix,
 )
 
 
-# if __name__ == "__main__":
-#     # uvicorn.run("main:app", reload=True)
-#     uvicorn.run(app)
+def run():
+    uvicorn.run(
+        "main:application",
+        host=settings.run.host,
+        port=settings.run.port,
+        reload=True,
+    )
+
+
+if __name__ == "__main__":
+    run()

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -1,5 +1,9 @@
+from unittest.mock import patch
 from fastapi.testclient import TestClient
-from app.main import app as application
+from app import main
+from app.main import application
+from app.core.config import settings
+
 
 client = TestClient(application)
 
@@ -17,3 +21,21 @@ def test_app_docs_available():
 def test_app_redoc_available():
     response = client.get("/redoc")
     assert response.status_code, 200
+
+
+def test_default_prefix_available():
+    response = client.get(settings.api.prefix)
+    assert response.status_code, 200
+
+
+@patch("uvicorn.run")
+def test_run_with_default_args2(mock_uvicorn_run):
+    """
+    Проверяет, что сервер запускается с параметрами,
+    совпадающими с настройками из конфига settings
+    """
+    main.run()
+    args, kwargs = mock_uvicorn_run.call_args
+    assert args[0] == "main:application"
+    assert kwargs["host"] == settings.run.host
+    assert kwargs["port"] == settings.run.port


### PR DESCRIPTION
Добавлены дефолтные параметры запуска сервера host, port, prefix

Протестировано, что сервер запускается с параметрами host, port, prefix, совпадающими с настройками из конфига settings

Добавлен .pytest_cache в .gitignore

Изменен способ запуска сервера, добавлена функция run(), запуск: python app/main.py
